### PR TITLE
Update for Magento 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "require": {
         "php": "^7.0 | ^7.1 | 7.2 | ^7.4",
         "phpunit/phpunit": "^6.2 | ^9.1",
-        "magento/framework": "^101.0 | ^102.0 | ^103.0"
+        "magento/framework": "^101.0 | ^102.0 | ^103.0 | ^104.0"
     }
 }


### PR DESCRIPTION
Updated dependencies to work with Magento 2.4.0, basing on https://github.com/magento/magento2/blob/2.4.0/composer.json